### PR TITLE
Add a utility to register and launch a TANGO device CB-1095

### DIFF
--- a/mkat_tango/translators/tango_launcher.py
+++ b/mkat_tango/translators/tango_launcher.py
@@ -1,0 +1,59 @@
+"""Utility to help launch a TANGO device in a KATCP eco-system
+
+Helps by auto-registering a TANGO device if needed
+
+"""
+import os
+import sys
+import argparse
+
+import PyTango
+
+from functools import partial
+
+parser = argparse.ArgumentParser(
+    description="Launch a TANGO device, handling registration as needed. "
+    "Assumes a separate server process per device (for now?).")
+
+required_argument = partial(parser.add_argument, required=True)
+
+# TODO NM 2106-05-26 We could accept multiple --name and --class parameters to
+# start multiple devices in a single server process?
+
+required_argument('--name', help="TANGO name for the device",)
+required_argument('--class', dest='device_class', help="TANGO class name for the device")
+required_argument('--server-command', help="TANGO server executable command")
+required_argument('--server-instance', help="TANGO server instance name")
+required_argument('--port', help="TCP port where TANGO server should listen")
+
+def register_device(name, device_class, server_name, instance):
+    dev_info = PyTango.DbDevInfo()
+    dev_info.name = name
+    dev_info._class = device_class
+    dev_info.server = "{}/{}".format(server_name, instance)
+    print """Attempting to register TANGO device {!r}
+    class: {!r}  server: {!r}.""".format(
+            dev_info.name, dev_info._class, dev_info.server)
+    db = PyTango.Database()
+    db.add_device(dev_info)
+
+def start_device(opts):
+    server_name = os.path.basename(opts.server_command)
+    register_device(
+        opts.name, opts.device_class, server_name, opts.server_instance)
+    args = [opts.server_command,
+            opts.server_instance,
+            '-ORBendPoint', 'giop:tcp::{}'.format(opts.port)]
+    print "Starting TANGO device server:\n{}".format(
+        " ".join(["{!r}".format(arg) for arg in args]))
+    print args
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os.execvp(opts.server_command, args)
+
+def main():
+    opts = parser.parse_args()
+    start_device(opts)
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup (
     'console_scripts': [
         'mkat-tango-weather-DS = mkat_tango.simulators.weather:weather_main',
         'mkat-tango-tangodevice2katcp = mkat_tango.translators.katcp_tango_proxy:tango2katcp_main',
+        'mkat-tango-tango_launcher = mkat_tango.translators.tango_launcher:main',
     ]},
 )


### PR DESCRIPTION
Command is called mkat-tango-tango_launcher

Combines running and registration into one step to ease use in a MeerKAT like
configuration.
