### PR TITLE
Add AP sim main + entry point, fix tango launcher

### DIFF
--- a/mkat_tango/simulators/mkat_ap_tango.py
+++ b/mkat_tango/simulators/mkat_ap_tango.py
@@ -525,7 +525,9 @@ class MkatAntennaPositioner(Device):
         #TODO Implement if required
         pass
 
+def main():
+    logging.basicConfig(level=logging.INFO)
+    server_run([MkatAntennaPositioner])
 
 if __name__ == "__main__":
-         logging.basicConfig(level=logging.DEBUG)
-         server_run([MkatAntennaPositioner])
+    main()

--- a/mkat_tango/translators/tango_launcher.py
+++ b/mkat_tango/translators/tango_launcher.py
@@ -30,7 +30,7 @@ parser.add_argument('--put-device-property', action='append', help=
                     "'device/name/X:property_name:property_value'. Only allows "
                     "properties to be set on devices started with this command. "
                     "Can be specified multiple times.",
-                    dest='device_properties')
+                    dest='device_properties', default=[])
 
 def register_device(name, device_class, server_name, instance):
     dev_info = PyTango.DbDevInfo()
@@ -45,6 +45,8 @@ def register_device(name, device_class, server_name, instance):
 
 def put_device_property(dev_name, property_name, property_value):
     db = PyTango.Database()
+    print "Setting device {!r} property {!r}: {!r}".format(
+        dev_name, property_name, property_value)
     db.put_device_property(dev_name, {property_name:[property_value]})
 
 def start_device(opts):
@@ -70,7 +72,6 @@ def start_device(opts):
             '-ORBendPoint', 'giop:tcp::{}'.format(opts.port)]
     print "Starting TANGO device server:\n{}".format(
         " ".join(["{!r}".format(arg) for arg in args]))
-    print args
     sys.stdout.flush()
     sys.stderr.flush()
     os.execvp(opts.server_command, args)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup (
     entry_points={
     'console_scripts': [
         'mkat-tango-weather-DS = mkat_tango.simulators.weather:weather_main',
+        'mkat-tango-AP-DS = mkat_tango.simulators.mkat_ap_tango:main',
         'mkat-tango-tangodevice2katcp = mkat_tango.translators.katcp_tango_proxy:tango2katcp_main',
         'mkat-tango-tango_launcher = mkat_tango.translators.tango_launcher:main',
     ]},


### PR DESCRIPTION
After most recent change the tango launcher would not work if no device
properties were specified.
