### PR TITLE
Add a conditional statement to check if the integer/float sensor has any params.

### DIFF
--- a/mkat_tango/translators/tango_katcp_proxy.py
+++ b/mkat_tango/translators/tango_katcp_proxy.py
@@ -85,8 +85,9 @@ def katcp_sensor2tango_attr(sensor):
     attr_name = katcpname2tangoname(sensor.name)
     attribute = Attr(attr_name, tango_type, AttrWriteType.READ)
     if sensor.stype in ['integer', 'float']:
-        attr_props.set_min_value(str(sensor.params[0]))
-        attr_props.set_max_value(str(sensor.params[1]))
+        if sensor.params:
+            attr_props.set_min_value(str(sensor.params[0]))
+            attr_props.set_max_value(str(sensor.params[1]))
 
     attr_props.set_label(sensor.name)
     attr_props.set_description(sensor.description)


### PR DESCRIPTION
@brickZA or @kmadisa please review and merge.
It seems some of the numerical type sensor (e.g. from ancillary proxy) have no max/min value parameters.
