### PR TITLE
Sort by sensor name when doing KATCP -> TANGO translation

### DIFF
--- a/mkat_tango/translators/tango_katcp_proxy.py
+++ b/mkat_tango/translators/tango_katcp_proxy.py
@@ -114,7 +114,9 @@ def add_tango_server_attribute_list(tango_dserver, sensors):
     None
 
     """
-    for sensor in sensors.values():
+    # Sort by sensor names so that the don't show up in the tango system in a
+    # random order.
+    for _, sensor in sorted(sensors.items()):
         attribute = katcp_sensor2tango_attr(sensor)
         tango_dserver.add_attribute(attribute, tango_dserver.read_attr)
 


### PR DESCRIPTION
If you add sensors to a tango device in a random order, they also show up in the
GUI tools in that order, making it somewhat hard to find the sensor you are
looking for.

Of course this would get messed up again if the KATCP interface changes and new
sensors are added, but better for now.
