### PR TITLE
Add a Jenkinsfile for multibranch tests on Slave433

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ node('Slave433') {
                     sh 'sudo service tango-db restart'
                     sh 'sudo pip install --egg git+https://github.com/tango-cs/PyTango.git@develop'
                     sh 'sudo pip install . -U'
-                    sh 'sudo pip install pip install nose_xunitmp nosexcover -U'
+                    sh 'sudo pip install nose_xunitmp nosexcover -U'
                     sh 'nosetests -v --with-xunitmp --xunitmp-file=nosetests.xml  --processes=1 --process-restartworker --process-timeout=400 .'
                 } finally {
                     step([$class: 'JUnitResultArchiver', testResults: 'nosetests.xml'])


### PR DESCRIPTION
On Jenkins we only use Slave433 for running mkat-tango unit tests, this file allows for a multibranch job for every branch that includes this file. It gives a nice green tick or red X if tests pass/fail.

Note that because this is the only tests we run on Slave433, we install stuff globally as sudo.
