### PR TITLE
Support TANGO-KATCP translated commands with arrayed datatype

### DIFF
--- a/mkat_tango/translators/katcp_tango_proxy.py
+++ b/mkat_tango/translators/katcp_tango_proxy.py
@@ -207,13 +207,21 @@ def tango_cmd_descr2katcp_request(tango_command_descr, tango_device_proxy):
 
     @kattypes.request(*request_args)
     @tornado.gen.coroutine
-    def request_handler_with_input(server, req, *input_param):
+    def request_handler_with_input(server, req, input_param):
         # TODO docstring using stuff?
         # A reference for debugging ease so that it is in the closure
         tango_device_proxy
-        tango_retval = yield tango_request(cmd_name, input_param[0] if
-                                           len(input_param) == 1 else
-                                           input_param)
+        tango_retval = yield tango_request(cmd_name, input_param)
+        raise Return(
+            ('ok', tango_retval) if tango_retval is not None else ('ok', ))
+
+    @kattypes.request(*request_args)
+    @tornado.gen.coroutine
+    def request_handler_with_array_input(server, req, *input_param):
+        # TODO docstring using stuff?
+        # A reference for debugging ease so that it is in the closure
+        tango_device_proxy
+        tango_retval = yield tango_request(cmd_name, input_param)
         raise Return(
             ('ok', tango_retval) if tango_retval is not None else ('ok', ))
 
@@ -227,7 +235,10 @@ def tango_cmd_descr2katcp_request(tango_command_descr, tango_device_proxy):
             ('ok', tango_retval) if tango_retval is not None else ('ok', ))
 
     if in_kattype:
-        handler = request_handler_with_input
+        if 'Array' in str(tango_command_descr.in_type):
+            handler = request_handler_with_array_input
+        else:
+            handler = request_handler_with_input
         in_type_desc = tango_command_descr.in_type_desc
     else:
         handler = request_handler_without_input

--- a/mkat_tango/translators/tests/test_katcp_tango_proxy.py
+++ b/mkat_tango/translators/tests/test_katcp_tango_proxy.py
@@ -228,6 +228,16 @@ class test_TangoDevice2KatcpProxyAsync(TangoDevice2KatcpProxy_BaseMixin,
                                      expected_reply_args=['ok', 1*3*7*9])
 
     @tornado.testing.gen_test
+    def test_cmd2request_MultiplyInt(self):
+        """Test request handler for the TangoTestServer MultiplyInts command
+        with a single item
+
+        """
+        yield self._test_cmd_handler(cmd_name='MultiplyInts',
+                                     request_args=[88],
+                                     expected_reply_args=['ok', 88])
+
+    @tornado.testing.gen_test
     def test_cmd2request_MultiplyDoubleBy3(self):
         """Test request handler for the TangoTestServer MultiplyDoubleBy2MultiplyInts command
 


### PR DESCRIPTION
We handle the DevVar*Array variants by checking if Array exists in the data type and then lookup the Scalar type. Then we just use multiple=True on the KATCP type