### PR TITLE
Removing references to the pytango-devicetest repo.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,6 @@ node('docker') {
         timestamps {
             timeout(time: 30, unit: 'MINUTES') {
                 try {
-                    // Install the stable version 0.1.3 of pytango-devicetest
-                    sh 'pip install --egg git+https://github.com/vxgmichel/pytango-devicetest.git@75c348959161b2c835b4ce6422294933c70e4915'
                     sh 'pip install nose_xunitmp'
                     sh 'pip install . -U'
                     sh 'python setup.py test --with-xunitmp --xunitmp-file nosetests.xml'

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ Tango segfaults when restarting a device main function
 PyTango segfaults if a device server is started more than once in a single
 process. This means that it is not possible to start/stop a tango device server
 as part of a test fixture. To work around this, the nose process plugin along
-with the `pytango-devicetest` module is used. Adding
+with the `tango.test_context` module is used. Adding
 `--processes=1 --process-restartworker --process-timeout=300` to a nose command
 line will cause each test tango device class (tango device fixtures are handled
 per-class) to be run in a new process.

--- a/ap-requirements.txt
+++ b/ap-requirements.txt
@@ -2,4 +2,3 @@ git+https://katpull:katpull4git@github.com/ska-sa/katversion#egg=katversion
 git+https://katpull:katpull4git@github.com/ska-sa/katcp-python#egg=katcp
 git+https://katpull:katpull4git@github.com/ska-sa/katcore#egg=katcore
 git+https://katpull:katpull4git@github.com/ska-sa/katproxy#egg=katproxy
-git+https://github.com/vxgmichel/pytango-devicetest.git#egg=python_devicetest

--- a/pip-build-requirements.txt
+++ b/pip-build-requirements.txt
@@ -5,4 +5,3 @@ git+ssh://git@github.com/ska-sa/katcp-python#egg=katcp
 git+ssh://git@github.com/ska-sa/katcore#egg=katcore
 git+ssh://git@github.com/ska-sa/katproxy#egg=katproxy
 git+ssh://git@github.com/ska-sa/tango-simlib#egg=tango_simlib
-git+ssh://git@github.com/vxgmichel/pytango-devicetest.git#egg=python_devicetest

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,8 @@ setup(name="mkat_tango",
       tests_require=[
           'enum',
           'numpy',
-          'nose_xunitmp',
-          'python-devicetest'],
+          'nose_xunitmp'],
       zip_safe=False,
-      dependency_links=[
-          'git+https://github.com/vxgmichel/pytango-devicetest.git#egg=python_devicetest'],
       entry_points={
           'console_scripts': [
               'mkat-tango-weather-DS = mkat_tango.simulators.weather:weather_main',


### PR DESCRIPTION
Now that PR #142 has been merged, we no longer need to install the [pytango-devicetest](https://github.com/vxgmichel/pytango-devicetest) library in order to run our unit tests. So we can now remove any references to it.

JIRA: [CB-2984](https://skaafrica.atlassian.net/browse/CB-2984)