### PR TITLE
Getting the number of items in both numpy.ndarray and tuple objects.

### DIFF
--- a/mkat_tango/translators/katcp_tango_proxy.py
+++ b/mkat_tango/translators/katcp_tango_proxy.py
@@ -532,7 +532,7 @@ class TangoDevice2KatcpProxy(object):
         """
         if name == "AttributesNotAdded":
             MODULE_LOGGER.debug("Sensor %s.* was never added on the KATCP server.",
-                               name)
+                                name)
             return
 
         attr_dformat = self.inspecting_client.device_attributes[name].data_format


### PR DESCRIPTION
**Getting the number of items in both numpy.ndarray and tuple objects.**

For spectrum type attributes the `update_sensor_values` method gets called with `value` having different object types. This all depends on the type of contents stored in the `value` iterable object. If the contents are strings, the `value` object is of type `tuple`. On the other hand if the contents are numericals, the type is a `numpy.ndarray` object. Our previous assumption was that the object would always be a `numpy.ndarray`. This PR fixes that. We modify the method to also handle `tuple` objects.

We also skip the creation of sensor objects for the attribute names stored in the _AttributeNotAdded_ attribute. There is a lot of them as seen in the screenshot below (they are not that important, so we do not translate them):

![screenshot from 2018-09-18 11-37-08](https://user-images.githubusercontent.com/16665803/45698431-41d0dc80-bb68-11e8-9463-5f37491360c9.png)


JIRA: [MT-145](https://skaafrica.atlassian.net/browse/MT-145)