### PR TITLE
Catching DevFailed error.

### DIFF
--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -237,6 +237,8 @@ class TangoInspectingClient(object):
                 retry = True
                 while retry and _retries < retries:
                     try:
+                        MODULE_LOGGER.info(
+                            "Setting up polling on attribute '%s'." % attr_name)
                         dp.poll_attribute(attr_name, poll_period)
                     except tango.DevFailed, exc:
                         exc_reasons = set([arg.reason for arg in exc.args])


### PR DESCRIPTION
This error is raised every time the client tries to set up polling on an already polled attribute, resulting in the translated _KATCP_ device failing to synchronise with the _TANGO_ device.

This change should solve the issues we have on [IntegrationTests-SKA-MPI-DSH](http://ci.camlab.kat.ac.za/job/IntegrationTests-SKA-MPI-DSH/)

**NB**: This issue is intermittent.

*Screenshots or code snippets (if appropriate):*

![screenshot from 2019-01-21 12-22-49](https://user-images.githubusercontent.com/16665803/51468365-769fab00-1d77-11e9-9f2a-906216472369.png)

Figure 1. A snapshot of the _s0000_ (dish proxy) logs.

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [MT-280](https://skaafrica.atlassian.net/browse/MT-280)
