### PR TITLE
Fixing string formatting error

### DIFF
--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -247,7 +247,7 @@ class TangoInspectingClient(object):
                             MODULE_LOGGER.info("Attribute '%s' already polled" % attr_name)
                         else:
                             MODULE_LOGGER.warning(
-                                "Setting polling on attribute '' failed on retry '%s'"
+                                "Setting polling on attribute '%s' failed on retry '%s'"
                                 ". Retrying again..." % (attr_name, _retries + 1),
                                 exc_info=True)
                             _retries += 1


### PR DESCRIPTION
This fixes the error:
`TypeError: not all arguments converted during string formatting`.

*Screenshots or code snippets (if appropriate):*
   - N/A

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [MT-280](https://skaafrica.atlassian.net/browse/MT-280)
