### PR TITLE
Subscribe to attribute events only for attrs whose event properties are set.

### DIFF
--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -257,20 +257,31 @@ class TangoInspectingClient(object):
                         MODULE_LOGGER.info("Polling on attribute '%s' was set up"
                                            " successfully" % attr_name)
    
+            events = self.device_attributes[attr_name].events
             if periodic:
                 self._subscribe_to_event(tango.EventType.PERIODIC_EVENT, attr_name)
             
             if change:
-                self._subscribe_to_event(tango.EventType.CHANGE_EVENT, attr_name)
+                if self._is_event_properties_set(events.ch_event):
+                    self._subscribe_to_event(tango.EventType.CHANGE_EVENT, attr_name)
             
             if archive:
-                self._subscribe_to_event(tango.EventType.ARCHIVE_EVENT, attr_name)
+                if self._is_event_properties_set(events.arch_event):
+                   self._subscribe_to_event(tango.EventType.ARCHIVE_EVENT, attr_name)
 
             if data_ready:
                 self._subscribe_to_event(tango.EventType.DATA_READY_EVENT, attr_name)
 
             if user:
                 self._subscribe_to_event(tango.EventType.USER_EVENT, attr_name)
+
+    def _is_event_properties_set(self, event_info):
+        for attr in dir(event_info):
+            if attr.startswith('__'):
+                continue
+            if getattr(event_info, attr) == 'Not specified':
+                return False
+        return True
 
     def clear_attribute_sampling(self):
         """Unsubscribe from all Tango events previously subscribed to


### PR DESCRIPTION
The _TANGO_ device's event thread sends event error messages when the client subscribes to attribute change/archive events when not all event properties are set for that attribute.
So to avoid getting those messages infinitely, we subscribe to those events only if all event properties are set.

*Screenshots or code snippets (if appropriate):*

![Screenshot from 2019-03-15 17-12-06](https://user-images.githubusercontent.com/16665803/54441554-b23a6e00-4745-11e9-97f9-f8946f419388.png)
**Figure 1**. A snapshot of the error messages from the event handler.

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [MT-283](https://skaafrica.atlassian.net/browse/MT-283)
