### PR TITLE
Changed Jenkinsfile script style to declarative style

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
                 timeout(time: 30, unit: 'MINUTES')
             }
             steps {
+                sh 'pip install nose_xunitmp --user'
                 sh 'pip install . -U --pre --user'
                 sh 'python setup.py test --with-xunitmp --xunitmp-file nosetests.xml'
             }


### PR DESCRIPTION
Port to new declarative syntax for Jenkins pipeline definitions in an attempting to fix our broken multibranch jobs because our new Jenkins agents inside containers don't have access to Docker daemon. this pull request is inline with a JIRA: [ MT-610](https://skaafrica.atlassian.net/secure/RapidBoard.jspa?rapidView=40&projectKey=MT&modal=detail&selectedIssue=MT-610), for reference please check this PR: [141](https://github.com/ska-sa/katconf/pull/141)