### PR TITLE
Iterate through array instead of using the max_dim_x property.

### DIFF
--- a/mkat_tango/translators/katcp_tango_proxy.py
+++ b/mkat_tango/translators/katcp_tango_proxy.py
@@ -541,9 +541,8 @@ class TangoDevice2KatcpProxy(object):
         katcp_name = tangoname2katcpname(name)
         attr_dformat = self.inspecting_client.device_attributes[name].data_format
         if attr_dformat == AttrDataFormat.SPECTRUM:
-            number_of_items = int(
-                self.inspecting_client.device_attributes[name].max_dim_x)
-            for index in xrange(number_of_items):
+
+            for index, value_ in enumerate(value):
                 try:
                     sensor = self.katcp_server.get_sensor(
                         "{}.{}".format(katcp_name, index))
@@ -558,7 +557,7 @@ class TangoDevice2KatcpProxy(object):
                             sensor.value(), status=status, timestamp=timestamp)
                     else:
                         sensor.set_value(
-                            value[index], status=status, timestamp=timestamp)
+                            value_, status=status, timestamp=timestamp)
         else:
             try:
                 sensor = self.katcp_server.get_sensor(katcp_name)


### PR DESCRIPTION
The size of the array assigned to the value of a spectrum type attribute is not fixed. We need to use it when updating the sensor values instead of using the max_dim_x property value.

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [N/A](https://skaafrica.atlassian.net/browse/JIRA_ISSUE_NUMBER)
