### PR TITLE
Report accurate sensor status for TANGO device

### DIFF
--- a/mkat_tango/translators/tests/test_katcp_tango_proxy.py
+++ b/mkat_tango/translators/tests/test_katcp_tango_proxy.py
@@ -423,7 +423,6 @@ class SensorObserver(object):
         LOGGER.debug('Received {!r} for attr {!r}'.format(sensor, reading))
 
 
-
 class test_TangoDeviceShutdown(ClassCleanupUnittestMixin, unittest.TestCase):
     """This tests that the sensor statuses change to failure when the we loose
        connection to the TANGO device.    
@@ -528,3 +527,4 @@ def cleanup_tempdir(*mkdtemp_args, **mkdtemp_kwargs):
                 raise
 
     return dirname
+


### PR DESCRIPTION
Adding a unit test that tests that the sensor statuses change to failure when we loose connection to the _TANGO_ device.


*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [MT-841](https://skaafrica.atlassian.net/browse/MT-841)
