### PR TITLE
ensure katcp informs are strings

### DIFF
--- a/mkat_tango/simulators/AntennaPositionerDS.py
+++ b/mkat_tango/simulators/AntennaPositionerDS.py
@@ -20,6 +20,8 @@ import time
 import weakref
 
 from functools import partial
+from past.builtins import cmp
+
 
 from tango import AttrQuality, DevState
 

--- a/mkat_tango/translators/katcp_tango_proxy.py
+++ b/mkat_tango/translators/katcp_tango_proxy.py
@@ -191,6 +191,7 @@ def tango_attr_descr2katcp_sensors(attr_descr):
         katcp_type_info = TANGO2KATCP_TYPE_INFO[attr_descr.data_type]
     except KeyError:
         data_type_name = TANGO_CMDARGTYPE_NUM2NAME[attr_descr.data_type]
+
         raise NotImplementedError("Unhandled attribute type {!r}".format(data_type_name))
 
     sensor_type = katcp_type_info.sensor_type
@@ -565,7 +566,6 @@ class TangoDevice2KatcpProxy(object):
 
         sensors_to_remove = list(set(sensors) - set(tango2katcp_sensors))
         sensors_to_add = list(set(tango2katcp_sensors) - set(sensors))
-
         for sensor_name in sensors_to_remove:
             self.katcp_server.remove_sensor(sensor_name)
 
@@ -580,7 +580,7 @@ class TangoDevice2KatcpProxy(object):
                 # Temporarily for unhandled attribute types
                 self._logger.debug(str(nierr), exc_info=True)
 
-        new_attributes = [sensor_attribute_map[sensor].name for sensor in sensors_to_add]
+        new_attributes = sorted(sensor_attribute_map[sensor].name for sensor in sensors_to_add)
         lower_case_attributes = [attr_name.lower() for attr_name in new_attributes]
         orig_attr_names_map = dict(list(zip(lower_case_attributes, new_attributes)))
         self.inspecting_client.orig_attr_names_map.update(orig_attr_names_map)
@@ -636,7 +636,6 @@ class TangoDevice2KatcpProxy(object):
         if name == "AttributesNotAdded":
             self._logger.debug("Sensor %s.* was never added on the KATCP server.", name)
             return
-
         katcp_name = tangoname2katcpname(name)
         # when we create KATCP sensors for spectrum attributes we add a dot before the
         # index. There could be a case where a device server has attributes that start

--- a/mkat_tango/translators/tango_katcp_proxy.py
+++ b/mkat_tango/translators/tango_katcp_proxy.py
@@ -14,11 +14,6 @@ from __future__ import absolute_import, division, print_function
 from future import standard_library
 standard_library.install_aliases()  # noqa: E402
 
-
-
-
-
-
 from builtins import object
 import logging
 import weakref
@@ -29,6 +24,7 @@ from concurrent.futures import Future
 from katcp import inspecting_client, ioloop_manager, Message
 from katcp.client import BlockingClient
 from katcp.core import Sensor
+from katcp.compat import ensure_native_str
 from tango import Attr, UserDefaultAttrProp, AttrWriteType, AttrQuality, Database
 from tango import DevDouble, DevLong64, DevBoolean, DevString, DevFailed, DevState
 from tango.server import Device, command, attribute
@@ -196,6 +192,7 @@ def create_command2request_handler(req_name, req_doc):
     command : tango.server.command obj
         Tango device server command
     """
+    req_doc = ensure_native_str(req_doc)
     if "Parameters" in req_doc:
 
         def cmd_handler(self, request_args):
@@ -399,7 +396,7 @@ class KatcpTango2DeviceProxy(object):
         def _wait_synced():
             try:
                 reply, informs = yield self.katcp_inspecting_client.simple_request(
-                    req, *request_args
+                    ensure_native_str(req), *request_args
                 )
             except Exception as exc:
                 f.set_exception(exc)
@@ -549,7 +546,7 @@ def get_katcp_request_data(katcp_connect_timeout=60.0):
     try:
         client.start()
         client.wait_connected(timeout=katcp_connect_timeout)
-        help_m = Message.request("help")
+        help_m = Message.request(ensure_native_str("help"))
         reply, informs = client.blocking_request(help_m)
     finally:
         client.stop()

--- a/mkat_tango/translators/tests/test_katcp_tango_proxy.py
+++ b/mkat_tango/translators/tests/test_katcp_tango_proxy.py
@@ -132,11 +132,11 @@ class test_TangoDevice2KatcpProxy(TangoDevice2KatcpProxy_BaseMixin, unittest.Tes
 
     def test_from_address(self):
         self.assertEqual(self.client.is_connected(), True)
-        reply, informs = self.client.blocking_request(Message.request("watchdog"))
+        reply, informs = self.client.blocking_request(Message.request(ensure_native_str("watchdog")))
         self.assertTrue(reply.reply_ok(), True)
 
     def test_sensor_attribute_match(self):
-        reply, informs = self.client.blocking_request(Message.request("sensor-list"))
+        reply, informs = self.client.blocking_request(Message.request(ensure_native_str("sensor-list")))
         sensor_list = {ensure_native_str(inform.arguments[0]) for inform in informs}
         attribute_list = set(self.tango_device_proxy.get_attribute_list())
 
@@ -297,7 +297,7 @@ class test_TangoDevice2KatcpProxy(TangoDevice2KatcpProxy_BaseMixin, unittest.Tes
     def test_request(self):
         mid = 5
         reply, _ = self.client.blocking_request(
-            Message.request("ReverseString", "polony", mid=mid)
+            Message.request(ensure_native_str("ReverseString"), ensure_native_str("polony"), mid=mid)
         )
         self.assertEqual(str(reply), "!ReverseString[{}] ok ynolop".format(mid))
 
@@ -372,7 +372,7 @@ class test_TangoDevice2KatcpProxy(TangoDevice2KatcpProxy_BaseMixin, unittest.Tes
             self.assertIn("test_attr", self.DUT.inspecting_client.orig_attr_names_map)
 
             # Check that attribute sampling was recalled for the new attribute
-            sec.assert_called_with(["test_attr", "ScalarDevEncoded"])
+            sec.assert_called_with(["ScalarDevEncoded", "test_attr"])
 
             # Remove the attribute.
             self.tango_test_device.remove_attribute("test_attr")

--- a/mkat_tango/translators/tests/test_tango_katcp_proxy.py
+++ b/mkat_tango/translators/tests/test_tango_katcp_proxy.py
@@ -26,6 +26,7 @@ from katcp import DeviceServer, Sensor, Message
 from katcp.kattypes import Float, Timestamp, request, return_reply
 from katcp.resource_client import IOLoopThreadWrapper
 from katcp.testutils import start_thread_with_cleanup
+from katcp.compat import ensure_native_str
 from tango.test_context import DeviceTestContext
 from tango_simlib.utilities.testutils import cleanup_tempfile
 
@@ -647,7 +648,8 @@ class test_KatcpTango2DeviceProxy(_test_KatcpTango2DeviceProxy):
                 # Address sensor type contains a Tuple contaning (host, port) and
                 # mapped to tango DevString type i.e "host:port"
                 sensor_value = ":".join(str(s) for s in sensor_value)
-            self.assertEqual(attribute_value, sensor_value)
+
+            self.assertAlmostEqual(attribute_value, sensor_value, places=6)
 
 
 class test_KatcpTango2DeviceProxyValidSensorsOnly(_test_KatcpTango2DeviceProxy):
@@ -750,7 +752,7 @@ class test_KatcpTango2DeviceProxyCommands(_test_KatcpTango2DeviceProxyCommands):
             reply = command(list(map(str, *args)))
         else:
             reply = command()
-        self.assertEqual(reply[0], "ok", "Request unsuccessful")
+        self.assertEqual(ensure_native_str(reply[0]), "ok", "Request unsuccessful")
         sensor_value = self.katcp_server.get_sensor(req)
         self.assertEqual(
             sensor_value.value(),

--- a/mkat_tango/translators/utilities.py
+++ b/mkat_tango/translators/utilities.py
@@ -15,6 +15,7 @@ standard_library.install_aliases()  # noqa: E402
 
 SENSOR_ATTRIBUTE_NAMES = {}
 
+from katcp.compat import ensure_native_str
 
 def katcpname2tangoname(sensor_name):
     """
@@ -36,6 +37,7 @@ def katcpname2tangoname(sensor_name):
         'actual_azim' or 'acs_temperature_01'
     """
     # TODO (KM) 13-06-2016 : Need to find a way to deal with sensor names with dots.
+    sensor_name = ensure_native_str(sensor_name)
     attribute_name = sensor_name.replace("-", "_").replace(".", "_")
     SENSOR_ATTRIBUTE_NAMES[attribute_name] = sensor_name
     return attribute_name

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "numpy",
         "tornado>=4.3, <5",
         "katcp",
-        "tango-simlib",
+        "tango-simlib>=0.5.0",
         "future",
         "futures; python_version<'3'",
     ],


### PR DESCRIPTION
This PR addresses the single unit test `test_sensor_attribute_match`
It is failing in the [Linitng branch](http://ci.camlab.kat.ac.za/job/mkat_tango-multibranch/job/user%252Ftockards%252FP2M-6%252FInitial-Futurize-stage2/7/#showFailuresLink) due to katcp informs being bytes and not strings.
This ensures that it is strings. 
The python2 tests are also passing. 


- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?

JIRA: [P2M-8](https://skaafrica.atlassian.net/browse/P2M-8)
