### PR TITLE
Pin PyTango to avoid failures relating to wheel building during insta…

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -5,7 +5,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     container:
-      image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:9.3.10
+      image: artefact.skao.int/ska-tango-images-pytango-builder:9.3.10
     steps:
       - uses: actions/checkout@v1
       - name: Install flake8

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -5,7 +5,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     container:
-      image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:9.3.1
+      image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:9.3.10
     steps:
       - uses: actions/checkout@v1
       - name: Install flake8

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -5,7 +5,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     container:
-      image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:9.3.3.1
+      image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:9.3.1
     steps:
       - uses: actions/checkout@v1
       - name: Install flake8

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     use_katversion=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
-        "PyTango>=9.3.2",
+        "PyTango==9.3.3",
         "numpy",
         "tornado>=4.3, <5",
         "katcp",


### PR DESCRIPTION
This PR does the following:
- Pins PyTango (9.3.3) which is the last known version that doesn't fail during installation due to pip-wheel building.


![image](https://user-images.githubusercontent.com/7910856/174968161-f7fd5298-00f2-4a4a-9e32-8e9a0c5e3f36.png)


JIRA: [MT-2980](https://skaafrica.atlassian.net/browse/MT-2980)
