### PR TITLE
Bump pytango version to 9.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker-registry.camlab.kat.ac.za/camtango_nodb_bionic:latest
 WORKDIR /usr/src/app
 COPY  . .
-RUN python2 -m pip install . -U
+# RUN python2 -m pip install . -U
 RUN python3 -m pip install . -U
 CMD ["tail", "-f"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,11 +44,11 @@ pipeline {
             }
 
             steps {
-                echo "Running nosetests on Python 2.7"
-                sh 'python2 -m pip install .'
-                sh 'python2 -m coverage run --source="${KATPACKAGE}" -m nose --with-xunitmp --xunitmp-file=nosetests_py27.xml'
-                sh 'python2 -m coverage xml -o coverage_27.xml'
-                sh 'python2 -m coverage report -m --skip-covered'
+                // echo "Running nosetests on Python 2.7"
+                // sh 'python2 -m pip install .'
+                // sh 'python2 -m coverage run --source="${KATPACKAGE}" -m nose --with-xunitmp --xunitmp-file=nosetests_py27.xml'
+                // sh 'python2 -m coverage xml -o coverage_27.xml'
+                // sh 'python2 -m coverage report -m --skip-covered'
 
                 echo "Running nosetests on Python 3.6"
                 sh 'python3 -m pip install -U .'

--- a/mkat_tango/translators/katcp_tango_proxy.py
+++ b/mkat_tango/translators/katcp_tango_proxy.py
@@ -761,7 +761,7 @@ class TangoDevice2KatcpProxy(object):
 
     @classmethod
     def from_addresses(
-        cls, katcp_server_address, tango_device_address, logger=log, polling=False
+        cls, katcp_server_address, tango_device_address, attrs_to_ignore=(), logger=log, polling=False
     ):
         """Instantiate TangoDevice2KatcpProxy from network addresses
 
@@ -774,7 +774,7 @@ class TangoDevice2KatcpProxy(object):
 
         """
         tango_device_proxy = cls.get_tango_device_proxy(tango_device_address)
-        tango_inspecting_client = TangoInspectingClient(tango_device_proxy, logger=logger)
+        tango_inspecting_client = TangoInspectingClient(tango_device_proxy, excluded_attributes=attrs_to_ignore, logger=logger)
         katcp_host, katcp_port = katcp_server_address
         katcp_server = TangoProxyDeviceServer(katcp_host, katcp_port)
         katcp_server.set_concurrency_options(thread_safe=False, handler_thread=False)

--- a/mkat_tango/translators/katcp_tango_proxy.py
+++ b/mkat_tango/translators/katcp_tango_proxy.py
@@ -170,12 +170,16 @@ def tango_to_katcp_text(text):
     Description strings from Tango devices have latin-1 encoding, but
     KATCP expects utf-8.  This is only in Python 2, not Python 3.
     """
-    if future.utils.PY2:
-        decoded = text.decode(encoding='latin-1')
-        encoded = decoded.encode(encoding='utf-8')
-        return encoded
-    else:
-        return text
+    try:
+        if future.utils.PY2:
+            decoded = text.decode(encoding='latin-1')
+            encoded = decoded.encode(encoding='utf-8')
+            return encoded
+        else:
+            return text
+    except Exception as e:
+        log.warn("Exception Message: %s", e)
+        return "decoding failed"
 
 
 def tango_attr_descr2katcp_sensors(attr_descr):
@@ -240,19 +244,24 @@ def tango_attr_descr2katcp_sensors(attr_descr):
             sensor_params = attr_descr.enum_labels
         elif attr_descr.data_type == CmdArgType.DevState:
             sensor_params = katcp_type_info.params
-
-        katcp_name = tangoname2katcpname(attr_descr.name)
-        if attr_descr.data_format == AttrDataFormat.SPECTRUM:
-            sensor_name = "{}.{}".format(katcp_name, index)
-        else:
-            sensor_name = katcp_name
-
+        try:
+            katcp_name = tangoname2katcpname(attr_descr.name)
+            if attr_descr.data_format == AttrDataFormat.SPECTRUM:
+                sensor_name = "{}.{}".format(katcp_name, index)
+            else:
+                sensor_name = katcp_name
+            description = attr_descr.description
+            unit = attr_descr.unit
+        except UnicodeDecodeError as e:
+            log.error("Exception: %s Sensor: %s", e, sensor_name)
+            description = "invalid description"
+            unit = "invalid unit"
         sensors.append(
             Sensor(
                 sensor_type,
                 sensor_name,
-                tango_to_katcp_text(attr_descr.description),
-                tango_to_katcp_text(attr_descr.unit),
+                tango_to_katcp_text(description),
+                tango_to_katcp_text(unit),
                 sensor_params,
             )
         )

--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -180,7 +180,8 @@ class TangoInspectingClient(object):
             event_type = event_data.event
             value = event_data.attr_value
             self._logger.error(
-                "Event system DevError(s) occured!!! %s", str(event_data.errors)
+                "Event system DevError(s) occured!!! %s, fqdn %s", str(event_data.errors),
+                fqdn_attr_name
             )
             self.sample_event_callback(
                 attr_name, received_timestamp, timestamp, value, quality, event_type
@@ -273,6 +274,7 @@ class TangoInspectingClient(object):
                     "Attribute {} has no event properties set".format(attribute_name)
                 )
             else:
+                self._logger.error("DeviceProxy: %s, error: %s", dp.name(), exc_reasons)
                 raise
         return subscribed
 

--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -83,9 +83,38 @@ class TangoInspectingClient(object):
             name
 
         """
+        excluded_attrs = (
+            "polyTrack",
+            "swVersions", # available in buildState
+            "fwVersions", # available in buildState
+            "serialNumbers", # available in buildState
+            "loggingTargets",
+            "maxCapabilities",
+            "frequencyResponse",
+            "programTrackTable",
+            "availableCapabilities",
+            # skao specific debug attributes that are not relevant to dvs
+            "lrcQueue",
+            "_lrcEvent",
+            "lrcFinished",
+            "lrcExecuting",
+            "lastCommandedMode",
+            "lastCommandUpdate",
+            "lastCommandInvoked",
+            "lrcProtocolVersions",
+            "longRunningCommandResult",
+            "longRunningCommandStatus",
+            "longRunningCommandsInQueue",
+            "longRunningCommandProgress",
+            "lastCommandedPointingParams",
+            "longRunningCommandIDsInQueue",
+            "longRunningCommandInProgress",
+        )
+
         return {
             attr_name.lower(): attr_name
             for attr_name in self.tango_dp.get_attribute_list()
+            if attr_name not in excluded_attrs
         }
 
     def inspect_attributes(self):
@@ -99,9 +128,38 @@ class TangoInspectingClient(object):
             :class: `tango._tango.AttributeInfoEx`, a return value of
             :meth:`tango.DeviceProxy.get_attribute_config` of each attribute.
         """
+        excluded_attrs = (
+            "polyTrack",
+            "swVersions", # available in buildState
+            "fwVersions", # available in buildState
+            "serialNumbers", # available in buildState
+            "loggingTargets",
+            "maxCapabilities",
+            "frequencyResponse",
+            "programTrackTable",
+            "availableCapabilities",
+            # skao specific debug attributes that are not relevant to dvs
+            "lrcQueue",
+            "_lrcEvent",
+            "lrcFinished",
+            "lrcExecuting",
+            "lastCommandedMode",
+            "lastCommandUpdate",
+            "lastCommandInvoked",
+            "lrcProtocolVersions",
+            "longRunningCommandResult",
+            "longRunningCommandStatus",
+            "longRunningCommandsInQueue",
+            "longRunningCommandProgress",
+            "lastCommandedPointingParams",
+            "longRunningCommandIDsInQueue",
+            "longRunningCommandInProgress",
+        )
+
         return {
             attr_name: self.tango_dp.get_attribute_config(attr_name)
             for attr_name in self.tango_dp.get_attribute_list()
+            if attr_name not in excluded_attrs
         }
 
     def inspect_commands(self):

--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -33,35 +33,7 @@ class TangoInspectingClient(object):
 
     """
 
-    EXCLUDED_ATTRS = (
-        "polyTrack",
-        "swVersions", # available in buildState aggregation
-        "fwVersions", # available in buildState aggregation
-        "serialNumbers", # available in buildState aggregation
-        "loggingTargets",
-        "maxCapabilities",
-        "frequencyResponse", # translates to 8202 sensors
-        "programTrackTable", # translates to 3000 sensors
-        "availableCapabilities",
-        # skao specific debug attributes that are not relevant to dvs
-        "lrcQueue",
-        "_lrcEvent",
-        "lrcFinished",
-        "lrcExecuting",
-        "lastCommandedMode",
-        "lastCommandUpdate",
-        "lastCommandInvoked",
-        "lrcProtocolVersions",
-        "longRunningCommandResult",
-        "longRunningCommandStatus",
-        "longRunningCommandsInQueue",
-        "longRunningCommandProgress",
-        "lastCommandedPointingParams",
-        "longRunningCommandIDsInQueue",
-        "longRunningCommandInProgress",
-    )
-
-    def __init__(self, tango_device_proxy, logger=log):
+    def __init__(self, tango_device_proxy, excluded_attributes=(),logger=log):
         self.tango_dp = tango_device_proxy
         self.device_attributes = {}
         self.device_commands = {}
@@ -69,6 +41,7 @@ class TangoInspectingClient(object):
         self._logger = logger
         self.orig_attr_names_map = {}
         self._interface_change_event_id = None
+        self._excluded_attributes = excluded_attributes
 
     def __del__(self):
         try:
@@ -115,7 +88,7 @@ class TangoInspectingClient(object):
         return {
             attr_name.lower(): attr_name
             for attr_name in self.tango_dp.get_attribute_list()
-            if attr_name not in self.EXCLUDED_ATTRS
+            if attr_name not in self._excluded_attributes
         }
 
     def inspect_attributes(self):
@@ -133,7 +106,7 @@ class TangoInspectingClient(object):
         return {
             attr_name: self.tango_dp.get_attribute_config(attr_name)
             for attr_name in self.tango_dp.get_attribute_list()
-            if attr_name not in self.EXCLUDED_ATTRS
+            if attr_name not in self._excluded_attributes
         }
 
     def inspect_commands(self):

--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -33,6 +33,34 @@ class TangoInspectingClient(object):
 
     """
 
+    EXCLUDED_ATTRS = (
+        "polyTrack",
+        "swVersions", # available in buildState aggregation
+        "fwVersions", # available in buildState aggregation
+        "serialNumbers", # available in buildState aggregation
+        "loggingTargets",
+        "maxCapabilities",
+        "frequencyResponse", # translates to 8202 sensors
+        "programTrackTable", # translates to 3000 sensors
+        "availableCapabilities",
+        # skao specific debug attributes that are not relevant to dvs
+        "lrcQueue",
+        "_lrcEvent",
+        "lrcFinished",
+        "lrcExecuting",
+        "lastCommandedMode",
+        "lastCommandUpdate",
+        "lastCommandInvoked",
+        "lrcProtocolVersions",
+        "longRunningCommandResult",
+        "longRunningCommandStatus",
+        "longRunningCommandsInQueue",
+        "longRunningCommandProgress",
+        "lastCommandedPointingParams",
+        "longRunningCommandIDsInQueue",
+        "longRunningCommandInProgress",
+    )
+
     def __init__(self, tango_device_proxy, logger=log):
         self.tango_dp = tango_device_proxy
         self.device_attributes = {}
@@ -83,38 +111,11 @@ class TangoInspectingClient(object):
             name
 
         """
-        excluded_attrs = (
-            "polyTrack",
-            "swVersions", # available in buildState
-            "fwVersions", # available in buildState
-            "serialNumbers", # available in buildState
-            "loggingTargets",
-            "maxCapabilities",
-            "frequencyResponse",
-            "programTrackTable",
-            "availableCapabilities",
-            # skao specific debug attributes that are not relevant to dvs
-            "lrcQueue",
-            "_lrcEvent",
-            "lrcFinished",
-            "lrcExecuting",
-            "lastCommandedMode",
-            "lastCommandUpdate",
-            "lastCommandInvoked",
-            "lrcProtocolVersions",
-            "longRunningCommandResult",
-            "longRunningCommandStatus",
-            "longRunningCommandsInQueue",
-            "longRunningCommandProgress",
-            "lastCommandedPointingParams",
-            "longRunningCommandIDsInQueue",
-            "longRunningCommandInProgress",
-        )
 
         return {
             attr_name.lower(): attr_name
             for attr_name in self.tango_dp.get_attribute_list()
-            if attr_name not in excluded_attrs
+            if attr_name not in self.EXCLUDED_ATTRS
         }
 
     def inspect_attributes(self):
@@ -128,38 +129,11 @@ class TangoInspectingClient(object):
             :class: `tango._tango.AttributeInfoEx`, a return value of
             :meth:`tango.DeviceProxy.get_attribute_config` of each attribute.
         """
-        excluded_attrs = (
-            "polyTrack",
-            "swVersions", # available in buildState
-            "fwVersions", # available in buildState
-            "serialNumbers", # available in buildState
-            "loggingTargets",
-            "maxCapabilities",
-            "frequencyResponse",
-            "programTrackTable",
-            "availableCapabilities",
-            # skao specific debug attributes that are not relevant to dvs
-            "lrcQueue",
-            "_lrcEvent",
-            "lrcFinished",
-            "lrcExecuting",
-            "lastCommandedMode",
-            "lastCommandUpdate",
-            "lastCommandInvoked",
-            "lrcProtocolVersions",
-            "longRunningCommandResult",
-            "longRunningCommandStatus",
-            "longRunningCommandsInQueue",
-            "longRunningCommandProgress",
-            "lastCommandedPointingParams",
-            "longRunningCommandIDsInQueue",
-            "longRunningCommandInProgress",
-        )
 
         return {
             attr_name: self.tango_dp.get_attribute_config(attr_name)
             for attr_name in self.tango_dp.get_attribute_list()
-            if attr_name not in excluded_attrs
+            if attr_name not in self.EXCLUDED_ATTRS
         }
 
     def inspect_commands(self):

--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -133,7 +133,8 @@ class TangoInspectingClient(object):
     def _update_device_attributes(self, attributes):
         self.device_attributes.clear()
         for attribute in attributes:
-            self.device_attributes[attribute.name] = attribute
+            if attribute.name not in self._excluded_attributes:
+                self.device_attributes[attribute.name] = attribute
 
     def interface_change_event_handler(self, event_data):
         """Handles tango device interface change events.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     use_katversion=True,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
-        "PyTango==9.3.3",
+        "PyTango==9.5",
         "numpy",
         "tornado>=4.3, <5",
         "katcp",


### PR DESCRIPTION
This PR bumps the pytango version to 9.5 for compatibility with MeerKAT extension Dish LMC and SKAO Dish LMC tango versions.

THIS VERSION OF PYTANGO IS NOT COMPATIBLE WITH PYTHON 2.7 and PYTHON 3.6 AND BREAKS CI!!!
See: [https://tango-controls.readthedocs.io/projects/pytango/en/v9.5.0/migration/to-9.5/deps-install.html](https://tango-controls.readthedocs.io/projects/pytango/en/v9.5.0/migration/to-9.5/deps-install.html)