### PR TITLE
Pass filtered list from tango device handler to tango device

### DIFF
--- a/mkat_tango/translators/katcp_tango_proxy.py
+++ b/mkat_tango/translators/katcp_tango_proxy.py
@@ -761,7 +761,7 @@ class TangoDevice2KatcpProxy(object):
 
     @classmethod
     def from_addresses(
-        cls, katcp_server_address, tango_device_address, logger=log, polling=False
+        cls, katcp_server_address, tango_device_address, attrs_to_ignore=(), logger=log, polling=False
     ):
         """Instantiate TangoDevice2KatcpProxy from network addresses
 
@@ -774,7 +774,7 @@ class TangoDevice2KatcpProxy(object):
 
         """
         tango_device_proxy = cls.get_tango_device_proxy(tango_device_address)
-        tango_inspecting_client = TangoInspectingClient(tango_device_proxy, logger=logger)
+        tango_inspecting_client = TangoInspectingClient(tango_device_proxy, excluded_attributes=attrs_to_ignore, logger=logger)
         katcp_host, katcp_port = katcp_server_address
         katcp_server = TangoProxyDeviceServer(katcp_host, katcp_port)
         katcp_server.set_concurrency_options(thread_safe=False, handler_thread=False)

--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -83,9 +83,38 @@ class TangoInspectingClient(object):
             name
 
         """
+        excluded_attrs = (
+            "polyTrack",
+            "swVersions", # available in buildState
+            "fwVersions", # available in buildState
+            "serialNumbers", # available in buildState
+            "loggingTargets",
+            "maxCapabilities",
+            "frequencyResponse",
+            "programTrackTable",
+            "availableCapabilities",
+            # skao specific debug attributes that are not relevant to dvs
+            "lrcQueue",
+            "_lrcEvent",
+            "lrcFinished",
+            "lrcExecuting",
+            "lastCommandedMode",
+            "lastCommandUpdate",
+            "lastCommandInvoked",
+            "lrcProtocolVersions",
+            "longRunningCommandResult",
+            "longRunningCommandStatus",
+            "longRunningCommandsInQueue",
+            "longRunningCommandProgress",
+            "lastCommandedPointingParams",
+            "longRunningCommandIDsInQueue",
+            "longRunningCommandInProgress",
+        )
+
         return {
             attr_name.lower(): attr_name
             for attr_name in self.tango_dp.get_attribute_list()
+            if attr_name not in excluded_attrs
         }
 
     def inspect_attributes(self):
@@ -99,9 +128,38 @@ class TangoInspectingClient(object):
             :class: `tango._tango.AttributeInfoEx`, a return value of
             :meth:`tango.DeviceProxy.get_attribute_config` of each attribute.
         """
+        excluded_attrs = (
+            "polyTrack",
+            "swVersions", # available in buildState
+            "fwVersions", # available in buildState
+            "serialNumbers", # available in buildState
+            "loggingTargets",
+            "maxCapabilities",
+            "frequencyResponse",
+            "programTrackTable",
+            "availableCapabilities",
+            # skao specific debug attributes that are not relevant to dvs
+            "lrcQueue",
+            "_lrcEvent",
+            "lrcFinished",
+            "lrcExecuting",
+            "lastCommandedMode",
+            "lastCommandUpdate",
+            "lastCommandInvoked",
+            "lrcProtocolVersions",
+            "longRunningCommandResult",
+            "longRunningCommandStatus",
+            "longRunningCommandsInQueue",
+            "longRunningCommandProgress",
+            "lastCommandedPointingParams",
+            "longRunningCommandIDsInQueue",
+            "longRunningCommandInProgress",
+        )
+
         return {
             attr_name: self.tango_dp.get_attribute_config(attr_name)
             for attr_name in self.tango_dp.get_attribute_list()
+            if attr_name not in excluded_attrs
         }
 
     def inspect_commands(self):

--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -33,35 +33,7 @@ class TangoInspectingClient(object):
 
     """
 
-    EXCLUDED_ATTRS = (
-        "polyTrack",
-        "swVersions", # available in buildState aggregation
-        "fwVersions", # available in buildState aggregation
-        "serialNumbers", # available in buildState aggregation
-        "loggingTargets",
-        "maxCapabilities",
-        "frequencyResponse", # translates to 8202 sensors
-        "programTrackTable", # translates to 3000 sensors
-        "availableCapabilities",
-        # skao specific debug attributes that are not relevant to dvs
-        "lrcQueue",
-        "_lrcEvent",
-        "lrcFinished",
-        "lrcExecuting",
-        "lastCommandedMode",
-        "lastCommandUpdate",
-        "lastCommandInvoked",
-        "lrcProtocolVersions",
-        "longRunningCommandResult",
-        "longRunningCommandStatus",
-        "longRunningCommandsInQueue",
-        "longRunningCommandProgress",
-        "lastCommandedPointingParams",
-        "longRunningCommandIDsInQueue",
-        "longRunningCommandInProgress",
-    )
-
-    def __init__(self, tango_device_proxy, logger=log):
+    def __init__(self, tango_device_proxy, excluded_attributes=(),logger=log):
         self.tango_dp = tango_device_proxy
         self.device_attributes = {}
         self.device_commands = {}
@@ -69,6 +41,7 @@ class TangoInspectingClient(object):
         self._logger = logger
         self.orig_attr_names_map = {}
         self._interface_change_event_id = None
+        self._excluded_attributes = excluded_attributes
 
     def __del__(self):
         try:
@@ -115,7 +88,7 @@ class TangoInspectingClient(object):
         return {
             attr_name.lower(): attr_name
             for attr_name in self.tango_dp.get_attribute_list()
-            if attr_name not in self.EXCLUDED_ATTRS
+            if attr_name not in self._excluded_attributes
         }
 
     def inspect_attributes(self):
@@ -133,7 +106,7 @@ class TangoInspectingClient(object):
         return {
             attr_name: self.tango_dp.get_attribute_config(attr_name)
             for attr_name in self.tango_dp.get_attribute_list()
-            if attr_name not in self.EXCLUDED_ATTRS
+            if attr_name not in self._excluded_attributes
         }
 
     def inspect_commands(self):

--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -33,6 +33,34 @@ class TangoInspectingClient(object):
 
     """
 
+    EXCLUDED_ATTRS = (
+        "polyTrack",
+        "swVersions", # available in buildState aggregation
+        "fwVersions", # available in buildState aggregation
+        "serialNumbers", # available in buildState aggregation
+        "loggingTargets",
+        "maxCapabilities",
+        "frequencyResponse", # translates to 8202 sensors
+        "programTrackTable", # translates to 3000 sensors
+        "availableCapabilities",
+        # skao specific debug attributes that are not relevant to dvs
+        "lrcQueue",
+        "_lrcEvent",
+        "lrcFinished",
+        "lrcExecuting",
+        "lastCommandedMode",
+        "lastCommandUpdate",
+        "lastCommandInvoked",
+        "lrcProtocolVersions",
+        "longRunningCommandResult",
+        "longRunningCommandStatus",
+        "longRunningCommandsInQueue",
+        "longRunningCommandProgress",
+        "lastCommandedPointingParams",
+        "longRunningCommandIDsInQueue",
+        "longRunningCommandInProgress",
+    )
+
     def __init__(self, tango_device_proxy, logger=log):
         self.tango_dp = tango_device_proxy
         self.device_attributes = {}
@@ -83,38 +111,11 @@ class TangoInspectingClient(object):
             name
 
         """
-        excluded_attrs = (
-            "polyTrack",
-            "swVersions", # available in buildState
-            "fwVersions", # available in buildState
-            "serialNumbers", # available in buildState
-            "loggingTargets",
-            "maxCapabilities",
-            "frequencyResponse",
-            "programTrackTable",
-            "availableCapabilities",
-            # skao specific debug attributes that are not relevant to dvs
-            "lrcQueue",
-            "_lrcEvent",
-            "lrcFinished",
-            "lrcExecuting",
-            "lastCommandedMode",
-            "lastCommandUpdate",
-            "lastCommandInvoked",
-            "lrcProtocolVersions",
-            "longRunningCommandResult",
-            "longRunningCommandStatus",
-            "longRunningCommandsInQueue",
-            "longRunningCommandProgress",
-            "lastCommandedPointingParams",
-            "longRunningCommandIDsInQueue",
-            "longRunningCommandInProgress",
-        )
 
         return {
             attr_name.lower(): attr_name
             for attr_name in self.tango_dp.get_attribute_list()
-            if attr_name not in excluded_attrs
+            if attr_name not in self.EXCLUDED_ATTRS
         }
 
     def inspect_attributes(self):
@@ -128,38 +129,11 @@ class TangoInspectingClient(object):
             :class: `tango._tango.AttributeInfoEx`, a return value of
             :meth:`tango.DeviceProxy.get_attribute_config` of each attribute.
         """
-        excluded_attrs = (
-            "polyTrack",
-            "swVersions", # available in buildState
-            "fwVersions", # available in buildState
-            "serialNumbers", # available in buildState
-            "loggingTargets",
-            "maxCapabilities",
-            "frequencyResponse",
-            "programTrackTable",
-            "availableCapabilities",
-            # skao specific debug attributes that are not relevant to dvs
-            "lrcQueue",
-            "_lrcEvent",
-            "lrcFinished",
-            "lrcExecuting",
-            "lastCommandedMode",
-            "lastCommandUpdate",
-            "lastCommandInvoked",
-            "lrcProtocolVersions",
-            "longRunningCommandResult",
-            "longRunningCommandStatus",
-            "longRunningCommandsInQueue",
-            "longRunningCommandProgress",
-            "lastCommandedPointingParams",
-            "longRunningCommandIDsInQueue",
-            "longRunningCommandInProgress",
-        )
 
         return {
             attr_name: self.tango_dp.get_attribute_config(attr_name)
             for attr_name in self.tango_dp.get_attribute_list()
-            if attr_name not in excluded_attrs
+            if attr_name not in self.EXCLUDED_ATTRS
         }
 
     def inspect_commands(self):


### PR DESCRIPTION
The tango device handler accepts a list to exclude some attributes when creating the sensor objects. This change updates the inspecting client to apply that filter when the device's interface is extracted.

Related PR:
- katcore: https://github.com/ska-sa/katcore/pull/170
- katmisc (dish proxy): https://github.com/ska-sa/katmisc/pull/215

JIRA: [KAR-2283](https://jira.skatelescope.org/browse/KAR-2283)

