### PR TITLE
KAR-2280: Prevent exluded attributes from coming back up on interface…

### DIFF
--- a/mkat_tango/translators/tango_inspecting_client.py
+++ b/mkat_tango/translators/tango_inspecting_client.py
@@ -133,7 +133,8 @@ class TangoInspectingClient(object):
     def _update_device_attributes(self, attributes):
         self.device_attributes.clear()
         for attribute in attributes:
-            self.device_attributes[attribute.name] = attribute
+            if attribute.name not in self._excluded_attributes:
+                self.device_attributes[attribute.name] = attribute
 
     def interface_change_event_handler(self, event_data):
         """Handles tango device interface change events.


### PR DESCRIPTION
Interface change populates full attribute set on resync - this change prevents population
